### PR TITLE
14-Correcciones-del-enunciado-1

### DIFF
--- a/repository/IngSoft2-Model/Dice.class.st
+++ b/repository/IngSoft2-Model/Dice.class.st
@@ -28,16 +28,8 @@ Internal Representation and Key Implementation Points.
 Class {
 	#name : #Dice,
 	#superclass : #Object,
-	#instVars : [
-		'numberOfFaces'
-	],
 	#category : #'IngSoft2-Model'
 }
-
-{ #category : #actions }
-Dice >> numberOfFaces [
-	^ numberOfFaces
-]
 
 { #category : #actions }
 Dice >> roll [

--- a/repository/IngSoft2-Model/Game.class.st
+++ b/repository/IngSoft2-Model/Game.class.st
@@ -35,21 +35,23 @@ Class {
 }
 
 { #category : #creation }
-Game class >> playedBy: aSetOfPlayers withStepsToWin: aStepsAmount  andUsing: dices [
+Game class >> playedBy: aSetOfPlayers withStepsToWin: aStepsAmount andUsing: dices [
 	^ self new
-		 initializeWithSteps: aStepsAmount players: aSetOfPlayers andUsing: dices;
-		 yourself.
+		initializeWithSteps: aStepsAmount
+			players: aSetOfPlayers
+			andUsing: dices;
+		yourself
 ]
 
-{ #category : #presentation }
-Game >> assertGameHasEnded [
+{ #category : #'private-assertions' }
+Game >> assertGameHasNotEnded [
 	self hasEnded
 		ifTrue: [ self error: 'Game is over. ' ]
 ]
 
-{ #category : #presentation }
-Game >> calculateValidPositionFor: aPlayer withRollResult: aNumberOfSteps. [
-	^ (aPlayer position + aNumberOfSteps) min: numberOfSteps
+{ #category : #actions }
+Game >> calculateValidPositionFor: aPlayer withRollResult: aNumberOfSteps [
+	^ aPlayer position + aNumberOfSteps min: numberOfSteps
 ]
 
 { #category : #status }
@@ -62,7 +64,7 @@ Game >> hasEnded [
 	^ players anySatisfy: [ :player | player position = numberOfSteps ]
 ]
 
-{ #category : #status }
+{ #category : #initialize }
 Game >> initializeWithSteps: aStepsAmount players: aSetOfPlayers andUsing: aSetOfDices [
 	players := aSetOfPlayers.
 	numberOfSteps := aStepsAmount.
@@ -70,21 +72,25 @@ Game >> initializeWithSteps: aStepsAmount players: aSetOfPlayers andUsing: aSetO
 	turnPosition := 1
 ]
 
-{ #category : #status }
+{ #category : #actions }
 Game >> rollDicesFor: aPlayer [
-	|newPosition|
-	newPosition := self calculateValidPositionFor: aPlayer withRollResult: (dices sum: #roll).
-	aPlayer moveTo: newPosition.
+	| newPosition |
+	newPosition := self
+		calculateValidPositionFor: aPlayer
+		withRollResult: (dices sum: #roll).
+	aPlayer moveTo: newPosition
 ]
 
-{ #category : #presentation }
+{ #category : #actions }
 Game >> turnIsPlayed [
-	self assertGameHasEnded.
+	self assertGameHasNotEnded.
 	self rollDicesFor: self currentPlayer.
 	turnPosition := turnPosition % players size + 1
 ]
 
-{ #category : #presentation }
+{ #category : #status }
 Game >> winner [
-	^ players detect: [ :player | player position = numberOfSteps ]
+	^ players
+		detect: [ :player | player position = numberOfSteps ]
+		ifNone: [ self error: 'There is no winner yet. The game is not finished' ]
 ]

--- a/repository/IngSoft2-Model/LoadedDice.class.st
+++ b/repository/IngSoft2-Model/LoadedDice.class.st
@@ -26,7 +26,7 @@ Internal Representation and Key Implementation Points.
     Implementation Points
 "
 Class {
-	#name : #SameFaceDice,
+	#name : #LoadedDice,
 	#superclass : #Dice,
 	#instVars : [
 		'value'
@@ -34,27 +34,26 @@ Class {
 	#category : #'IngSoft2-Model'
 }
 
-{ #category : #asserting }
-SameFaceDice class >> assertValidThatADiceHas3OrMoreFaces: aNumberOfFaces [
+{ #category : #'private-assertions' }
+LoadedDice class >> assertValidNumberOfFaces: aNumberOfFaces [
 	aNumberOfFaces > 3
 		ifFalse: [ self error: 'Number of faces must be 4 or greater' ]
 ]
 
 { #category : #creation }
-SameFaceDice class >> withFaces: aNumberOfFaces andValue: aNumber [
-	self assertValidThatADiceHas3OrMoreFaces: aNumberOfFaces.
+LoadedDice class >> withFaces: aNumberOfFaces andValue: aNumber [
+	self assertValidNumberOfFaces: aNumberOfFaces.
 	^ self new
 		initializeWithFaces: aNumberOfFaces andValue: aNumber;
 		yourself
 ]
 
 { #category : #initialize }
-SameFaceDice >> initializeWithFaces: aNumberOfFaces andValue: aNumber [
-	numberOfFaces := aNumberOfFaces.
+LoadedDice >> initializeWithFaces: aNumberOfFaces andValue: aNumber [
 	value := aNumber
 ]
 
 { #category : #actions }
-SameFaceDice >> roll [
+LoadedDice >> roll [
 	^ value
 ]

--- a/repository/IngSoft2-Model/Player.class.st
+++ b/repository/IngSoft2-Model/Player.class.st
@@ -29,14 +29,14 @@ Class {
 	#name : #Player,
 	#superclass : #Object,
 	#instVars : [
-		'playerName',
+		'name',
 		'position'
 	],
 	#category : #'IngSoft2-Model'
 }
 
 { #category : #creation }
-Player class >> called: aName [
+Player class >> named: aName [
 	^ self new
 		initializeWithName: aName;
 		yourself
@@ -44,18 +44,18 @@ Player class >> called: aName [
 
 { #category : #initialize }
 Player >> initializeWithName: aName [
-	playerName := aName.
+	name := aName.
 	position := 0
 ]
 
-{ #category : #initialize }
+{ #category : #actions }
 Player >> moveTo: newPosition [
 	position := newPosition
 ]
 
 { #category : #presentation }
 Player >> name [
-	^ playerName
+	^ name
 ]
 
 { #category : #actions }

--- a/repository/IngSoft2-Model/RandomDice.class.st
+++ b/repository/IngSoft2-Model/RandomDice.class.st
@@ -4,18 +4,21 @@ I am a random dice.
 Class {
 	#name : #RandomDice,
 	#superclass : #Dice,
+	#instVars : [
+		'numberOfFaces'
+	],
 	#category : #'IngSoft2-Model'
 }
 
-{ #category : #creation }
-RandomDice class >> assertValidThatADiceHas3OrMoreFaces: aNumberOfFaces [
+{ #category : #'private-assertions' }
+RandomDice class >> assertValidNumberOfFaces: aNumberOfFaces [
 	aNumberOfFaces > 3
-		ifFalse: [ self error: 'Number of faces must be 4 or greater' ]
+		ifFalse: [ self error: 'Number of faces must be greater than 3' ]
 ]
 
 { #category : #creation }
 RandomDice class >> withFaces: aNumberOfFaces [
-	self assertValidThatADiceHas3OrMoreFaces: aNumberOfFaces.
+	self assertValidNumberOfFaces: aNumberOfFaces.
 	^ self new
 		initializeWithFaces: aNumberOfFaces;
 		yourself
@@ -24,6 +27,11 @@ RandomDice class >> withFaces: aNumberOfFaces [
 { #category : #initialize }
 RandomDice >> initializeWithFaces: aNumberOfFaces [
 	numberOfFaces := aNumberOfFaces
+]
+
+{ #category : #actions }
+RandomDice >> numberOfFaces [
+	^ numberOfFaces
 ]
 
 { #category : #actions }

--- a/repository/IngSoft2-Tests/DiceTest.class.st
+++ b/repository/IngSoft2-Tests/DiceTest.class.st
@@ -9,9 +9,27 @@ Class {
 
 { #category : #tests }
 DiceTest >> testDiceCantHaveLessThanFourFaces [
-	self should: [ RandomDice withFaces: 3 ] raise: Error.
-	self should: [ RandomDice withFaces: 0 ] raise: Error.
-	self should: [ RandomDice withFaces: -1 ] raise: Error
+	self
+		should: [ RandomDice withFaces: 3 ]
+		raise: Error
+		withExceptionDo: [ :signal | 
+			self
+				assert: signal messageText
+				equals: 'Number of faces must be greater than 3' ].
+	self
+		should: [ RandomDice withFaces: 0 ]
+		raise: Error
+		withExceptionDo: [ :signal | 
+			self
+				assert: signal messageText
+				equals: 'Number of faces must be greater than 3' ].
+	self
+		should: [ RandomDice withFaces: -1 ]
+		raise: Error
+		withExceptionDo: [ :signal | 
+			self
+				assert: signal messageText
+				equals: 'Number of faces must be greater than 3' ]
 ]
 
 { #category : #tests }
@@ -19,7 +37,7 @@ DiceTest >> testDiceRollsAndReturnsAValidNumber [
 	| fourFacesDice rollingResult |
 	fourFacesDice := RandomDice withFaces: 4.
 	rollingResult := fourFacesDice roll.
-	self assert: (rollingResult >= 1 and: rollingResult <= 4)
+	self assert: (rollingResult between: 1 and: 4)
 ]
 
 { #category : #tests }

--- a/repository/IngSoft2-Tests/GameTest.class.st
+++ b/repository/IngSoft2-Tests/GameTest.class.st
@@ -5,7 +5,6 @@ Class {
 	#name : #GameTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'fourFaceDummyDice',
 		'dices',
 		'players',
 		'game',
@@ -16,40 +15,62 @@ Class {
 
 { #category : #running }
 GameTest >> setUp [
+	| fourFaceDummyDice |
 	super setUp.
-	fourFaceDummyDice := SameFaceDice withFaces: 4 andValue: 4.
-	dices := LinkedList with: fourFaceDummyDice.
-	robert := Player called: 'Robert'.
-	players := LinkedList with: robert.
-	game := Game playedBy: players withStepsToWin: 3 andUsing: dices
+	fourFaceDummyDice := LoadedDice withFaces: 4 andValue: 4.
+	dices := OrderedCollection with: fourFaceDummyDice.
+	robert := Player named: 'Robert'.
+	players := OrderedCollection with: robert
+]
+
+{ #category : #tests }
+GameTest >> testCanNotGetWinnerWhileGameIsRunning [
+	game := Game playedBy: players withStepsToWin: 3 andUsing: dices.
+	self deny: game hasEnded.
+	self
+		should: [ game winner ]
+		raise: Error
+		withExceptionDo: [ :signal | 
+			self
+				assert: signal messageText
+				equals: 'There is no winner yet. The game is not finished' ]
 ]
 
 { #category : #tests }
 GameTest >> testGameCantBePlayedOnceItIsOver [
-	| lucia |
-	lucia := Player called: 'Lucia'.
-	players add: lucia.
+	game := Game playedBy: players withStepsToWin: 3 andUsing: dices.
 	game turnIsPlayed.
-	self should: [ game turnIsPlayed  ] raise: Error
+	self
+		should: [ game turnIsPlayed ]
+		raise: Error
+		withExceptionDo: [ :signal | 
+			self
+				assert: signal messageText
+				equals: 'Game is over. ' ]
 ]
 
 { #category : #tests }
 GameTest >> testGameHasEnded [
+	game := Game playedBy: players withStepsToWin: 3 andUsing: dices.
+	self deny: game hasEnded.
 	game turnIsPlayed.
 	self assert: game hasEnded
 ]
 
 { #category : #tests }
 GameTest >> testGetWinnerOnceGameIsFinished [
+	game := Game playedBy: players withStepsToWin: 3 andUsing: dices.
+	self deny: game hasEnded.
 	game turnIsPlayed.
+	self assert: game hasEnded.
 	self assert: game winner name equals: 'Robert'
 ]
 
 { #category : #tests }
 GameTest >> testIsRobertTurn [
 	| matt martin |
-	matt := Player called: 'Matt'.
-	martin := Player called: 'Martin'.
+	matt := Player named: 'Matt'.
+	martin := Player named: 'Martin'.
 	players add: matt.
 	players add: martin.
 	game := Game playedBy: players withStepsToWin: 20 andUsing: dices.
@@ -60,29 +81,31 @@ GameTest >> testIsRobertTurn [
 ]
 
 { #category : #tests }
-GameTest >> testPlayerMovesNineStepsWhenUsingTwoDices [
-	| fiveFaceDummyDice |
-	game := Game playedBy: players withStepsToWin: 9 andUsing: dices.
-	fiveFaceDummyDice := SameFaceDice withFaces: 5 andValue: 5.
-	dices add: fiveFaceDummyDice.
-	game turnIsPlayed.
-	self assert: robert position equals: 9
-]
-
-{ #category : #tests }
-GameTest >> testPlayerMovesThreeStepsWhenHeGetsAFour [
+GameTest >> testPlayerGetsA4AndMoves3BecouseTheGameHas3StepsToWin [
+	game := Game playedBy: players withStepsToWin: 3 andUsing: dices.
 	game turnIsPlayed.
 	self assert: robert position equals: 3
 ]
 
 { #category : #tests }
+GameTest >> testPlayerMovesNineStepsWhenUsingTwoDices [
+	| fiveFaceDummyDice |
+	fiveFaceDummyDice := LoadedDice withFaces: 5 andValue: 5.
+	dices add: fiveFaceDummyDice.
+	game := Game playedBy: players withStepsToWin: 9 andUsing: dices.
+	game turnIsPlayed.
+	self assert: robert position equals: 9
+]
+
+{ #category : #tests }
 GameTest >> testThatLuciaCanNotPlayBecouseGameHasEnded [
-	| lucia lucas |
-	lucia := Player called: 'Lucia'.
-	lucas := Player called: 'Lucas'.
+	| lucia |
+	lucia := Player named: 'Lucia'.
 	players add: lucia.
-	players add: lucas.
 	game := Game playedBy: players withStepsToWin: 4 andUsing: dices.
 	game turnIsPlayed.
-	self should: [ game turnIsPlayed ] raise: Error
+	self
+		should: [ game turnIsPlayed ]
+		raise: Error
+		withExceptionDo: [ :signal | self assert: signal messageText equals: 'Game is over. ' ]
 ]

--- a/repository/IngSoft2-Tests/PlayerTest.class.st
+++ b/repository/IngSoft2-Tests/PlayerTest.class.st
@@ -8,16 +8,17 @@ Class {
 }
 
 { #category : #tests }
-PlayerTest >> testAPlayerCalledRobertWithInitialPositionZero [
+PlayerTest >> testAPlayerNamedRobertMovetoPositionNumberFour [
 	| player |
-	player := Player called: 'Robert'.
-	self assert: player name equals: 'Robert'.
-	self assert: player position equals: 0
+	player := Player named: 'Robert'.
+	player moveTo: 4.
+	self assert: player position equals: 4
 ]
 
 { #category : #tests }
-PlayerTest >> testInitialPositionOfRobertIsZero [
+PlayerTest >> testAPlayerNamedRobertWithInitialPositionZero [
 	| player |
-	player := Player called: 'Robert'.
+	player := Player named: 'Robert'.
+	self assert: player name equals: 'Robert'.
 	self assert: player position equals: 0
 ]


### PR DESCRIPTION
- Se eliminó el mensaje "numberOfFaces" en la clase "Dice".
- Se movieron los mensajes de "assetion" al protocolo "private-assertions" en las diferentes clases.
-  Se cambió "SameFaceDice" a "LoadedDice".
-  Se cambió el nombre del mensaje "called:" en Player a "named:".
- Se agregó el test "testCanNotGetWinnerWhileGameIsRunning".
- Se cambió el nombre del test "testPlayerMovesThreeStepsWhenHeGetsAFour" a "testPlayerGetsA4AndMoves3BecouseTheGameHas3StepsToWin".
- Se eliminó el test "testAPlayerCalledRobertWithInitialPositionZero" porque ya habí­a otro test que hací­a lo mismo.